### PR TITLE
Event sign up fix

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -4,21 +4,19 @@
     <value>
       <entry key="Unnamed">
         <State>
-          <targetSelectedWithDropDown>
+          <runningDeviceTargetSelectedWithDropDown>
             <Target>
-              <type value="QUICK_BOOT_TARGET" />
+              <type value="RUNNING_DEVICE_TARGET" />
               <deviceKey>
                 <Key>
                   <type value="VIRTUAL_DEVICE_PATH" />
-                  <value value="$USER_HOME$/.android/avd/Pixel_6_API_34.avd" />
+                  <value value="$USER_HOME$/.android/avd/Pixel_6_Pro_API_34.avd" />
                 </Key>
               </deviceKey>
             </Target>
-          </targetSelectedWithDropDown>
-          <timeTargetWasSelectedWithDropDown value="2024-04-06T18:11:25.006267Z" />
+          </runningDeviceTargetSelectedWithDropDown>
+          <timeTargetWasSelectedWithDropDown value="2024-04-07T02:34:00.952906Z" />
         </State>
-      <entry key="app">
-        <State />
       </entry>
     </value>
   </component>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -10,12 +10,12 @@
               <deviceKey>
                 <Key>
                   <type value="VIRTUAL_DEVICE_PATH" />
-                  <value value="$USER_HOME$/.android/avd/Pixel_6_Pro_API_34.avd" />
+                  <value value="$USER_HOME$/.android/avd/Pixel_6_API_34.avd" />
                 </Key>
               </deviceKey>
             </Target>
           </runningDeviceTargetSelectedWithDropDown>
-          <timeTargetWasSelectedWithDropDown value="2024-04-07T02:34:00.952906Z" />
+          <timeTargetWasSelectedWithDropDown value="2024-04-07T02:54:42.096475Z" />
         </State>
       </entry>
     </value>

--- a/app/src/main/java/com/example/swiftcheckin/attendee/AnnoucementActivity.java
+++ b/app/src/main/java/com/example/swiftcheckin/attendee/AnnoucementActivity.java
@@ -59,9 +59,6 @@ public class AnnoucementActivity extends AppCompatActivity {
     EventSignUp eventSignUp = new EventSignUp();
     private FirebaseAttendee fb;
 
-    private boolean eventCheckflag;
-
-
 
     /**
      * Initializes the activity and sets up necessary components.
@@ -107,8 +104,6 @@ public class AnnoucementActivity extends AppCompatActivity {
             sign_up.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    DocumentReference eventCheckRef = fb.getDb().collection("events").document(eventId);
-
                     if (!eventMaxAttendees.equals(eventCurrentAttendees)) {
                         fb.saveSignUpData(deviceId, eventId, AnnoucementActivity.this);
                         eventSignUp.addAttendeeToEvent(eventId, deviceId, eventMaxAttendees, eventCurrentAttendees);
@@ -124,7 +119,7 @@ public class AnnoucementActivity extends AppCompatActivity {
                                     }
                                 });
                     } else {
-                                        Toast.makeText(getApplicationContext(), "Event is full", Toast.LENGTH_SHORT).show();
+                        Toast.makeText(getApplicationContext(), "Event is full", Toast.LENGTH_SHORT).show();
 //                        sign_up.setBackgroundColor(Color.LTGRAY);
                     }
                 }

--- a/app/src/main/java/com/example/swiftcheckin/attendee/AnnoucementActivity.java
+++ b/app/src/main/java/com/example/swiftcheckin/attendee/AnnoucementActivity.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 // Right now there is no way to unsign up for an event
 /**
  * This class deals with the announcement activity to show details and announcements of an event as well as allowing attendees to sign up for an event.
@@ -57,6 +58,8 @@ public class AnnoucementActivity extends AppCompatActivity {
     private AnnouncementArrayAdapter announceAdapter; // Adapter meant to keep track of changes in the number of events.
     EventSignUp eventSignUp = new EventSignUp();
     private FirebaseAttendee fb;
+
+    private boolean eventCheckflag;
 
 
 
@@ -90,9 +93,22 @@ public class AnnoucementActivity extends AppCompatActivity {
         if (eventMaxAttendees.equals(eventCurrentAttendees)) {
             sign_up.setBackgroundColor(Color.LTGRAY);
         }
+        DocumentReference eventCheckRef = fb.getDb().collection("events").document(eventId);
+        eventCheckRef.addSnapshotListener(new EventListener<DocumentSnapshot>() {
+            @Override
+            public void onEvent(@Nullable DocumentSnapshot value, @Nullable FirebaseFirestoreException error) {
+                if (!value.exists()){
+                    Toast.makeText(getApplicationContext(), "Event has been deleted by admin.", Toast.LENGTH_SHORT).show();
+                    finish();
+                }
+            }
+        });
+
             sign_up.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
+                    DocumentReference eventCheckRef = fb.getDb().collection("events").document(eventId);
+
                     if (!eventMaxAttendees.equals(eventCurrentAttendees)) {
                         fb.saveSignUpData(deviceId, eventId, AnnoucementActivity.this);
                         eventSignUp.addAttendeeToEvent(eventId, deviceId, eventMaxAttendees, eventCurrentAttendees);
@@ -108,11 +124,11 @@ public class AnnoucementActivity extends AppCompatActivity {
                                     }
                                 });
                     } else {
-                        Toast.makeText(getApplicationContext(), "Event is full", Toast.LENGTH_SHORT).show();
+                                        Toast.makeText(getApplicationContext(), "Event is full", Toast.LENGTH_SHORT).show();
 //                        sign_up.setBackgroundColor(Color.LTGRAY);
                     }
-
                 }
+
             });
 
 
@@ -215,6 +231,7 @@ public class AnnoucementActivity extends AppCompatActivity {
             }
         });
     }
+
 
 
 }

--- a/app/src/main/java/com/example/swiftcheckin/organizer/EventSignUp.java
+++ b/app/src/main/java/com/example/swiftcheckin/organizer/EventSignUp.java
@@ -89,7 +89,6 @@ public class EventSignUp {
             currentAttendees += 1;
 
             eventCurrentAttendees = Integer.toString(currentAttendees);
-
             DocumentReference updateEventDoc = db.collection("events").document(eventId);
             HashMap<String, String> data2 = new HashMap<>();
             data2.put("eventCurrentAttendees", eventCurrentAttendees);


### PR DESCRIPTION
I fixed the edge case of admin deleting an event while somebody is on the announcementActivity by adding a SnapshotListener which check whether a document exists or not. If a document, which refers to the event, then the activity will finish. If a user signs up and remains on the activity, then the activity will finish. If the user does not sign up before admin deletes the event, then the activity cancels. 

The only possible scenario which may cause issues is if admin deletes and attendee signs up at the exact same time.